### PR TITLE
Change clone command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG GNURADIO_TAG
 
 WORKDIR /root
 # includes rx_freq tag - https://github.com/gnuradio/gnuradio/commit/915601c4a5d994532815fbd5c75a3c34f1fbd320
-RUN git clone https://github.com/gnuradio/gnuradio -b ${GNURADIO_TAG}
+RUN git clone --depth 1 https://github.com/gnuradio/gnuradio -b ${GNURADIO_TAG}
 WORKDIR /root/gnuradio/build
 RUN CMAKE_CXX_STANDARD=17 cmake -DENABLE_DEFAULT=ON -DENABLE_PYTHON=ON -DENABLE_GNURADIO_RUNTIME=ON -DENABLE_GR_BLOCKS=ON -DENABLE_GR_FFT=ON -DENABLE_GR_FILTER=ON -DENABLE_GR_ANALOG=ON -DENABLE_GR_UHD=ON -DENABLE_GR_NETWORK=ON -DENABLE_GR_SOAPY=ON -DENABLE_GR_ZEROMQ=ON .. && make -j "$(nproc)" && make install
 
@@ -13,10 +13,10 @@ FROM iqtlabs/gnuradio-dependencies:${DEPENDENCIES_VERSION} as driver-builder
 COPY --from=gr-builder /usr/local /usr/local
 
 WORKDIR /root
-RUN git clone https://github.com/pothosware/SoapyBladeRF -b soapy-bladerf-0.4.1
-RUN git clone https://github.com/pothosware/SoapyUHD -b soapy-uhd-0.4.1
-RUN git clone https://github.com/Nuand/bladeRF.git -b 2023.02
-RUN git clone https://github.com/anarkiwi/lime-tools -b samples
+RUN git clone --depth 1 https://github.com/pothosware/SoapyBladeRF -b soapy-bladerf-0.4.1
+RUN git clone --depth 1 https://github.com/pothosware/SoapyUHD -b soapy-uhd-0.4.1
+RUN git clone --depth 1 https://github.com/Nuand/bladeRF.git -b 2023.02
+RUN git clone --depth 1 https://github.com/anarkiwi/lime-tools -b samples
 WORKDIR /root/SoapyBladeRF/build
 RUN cmake .. && make -j "$(nproc)" && make install
 WORKDIR /root/SoapyUHD/build

--- a/Dockerfile.dependencies
+++ b/Dockerfile.dependencies
@@ -43,9 +43,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends software-proper
 RUN /usr/lib/uhd/utils/uhd_images_downloader.py -t "b2|usb"
 WORKDIR /root
 # https://wiki.gnuradio.org/index.php/GNU_Radio_3.9_OOT_Module_Porting_Guide
-RUN git clone https://github.com/pybind/pybind11 -b v2.11.1
-RUN git clone https://github.com/gnuradio/volk -b v3.0.0
-RUN git clone https://github.com/pothosware/SoapySDR -b soapy-sdr-0.8.1
+RUN git clone --depth 1 https://github.com/pybind/pybind11 -b v2.11.1
+RUN git clone --depth 1 https://github.com/gnuradio/volk -b v3.0.0
+RUN git clone --depth 1 https://github.com/pothosware/SoapySDR -b soapy-sdr-0.8.1
 WORKDIR /root/pybind11/build
 RUN cmake -DPYBIND11_TEST="" .. && make -j "$(nproc)" && make install
 WORKDIR /root/volk/build


### PR DESCRIPTION
clone with `--depth 1`

in the future, for all CI/CD pipeline and workflow use cases, we should clone with `--depth 1` so that we only retrieve the latest commit from the desired repo. Our workflows don't need to pull down the entire history just to do a build and this will save time and network traffic, particularly in constrained environments.